### PR TITLE
wrangler: set SSL_CERT_FILE

### DIFF
--- a/pkgs/wrangler/package.nix
+++ b/pkgs/wrangler/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  cacert,
   fetchFromGitHub,
   makeWrapper,
   nodejs,
@@ -101,7 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${lib.getExe nodejs} $out/bin/wrangler \
       --inherit-argv0 \
       --prefix-each NODE_PATH : "$${NODE_PATH_ARRAY[@]}" \
-      --add-flags $out/lib/packages/wrangler/bin/wrangler.js
+      --add-flags $out/lib/packages/wrangler/bin/wrangler.js \
+      --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" # https://github.com/cloudflare/workers-sdk/issues/3264
     runHook postInstall
   '';
 })


### PR DESCRIPTION
@ryand56 - thanks for updating this repo with latest versions - I love being able to do `nix flake update` in my `wrangler` projects and it just pulls down the latest version of `wrangler`.

I never got around to notifying the cloudflare folks and ask them how we could potentially make this smaller - we should still do this I think.

This PR is a copy of https://github.com/NixOS/nixpkgs/pull/330808 by @getchoo which we should include here.
