### PR TITLE
ci: run workflows correctly for PRs

### DIFF
--- a/.github/workflows/eval-check.yml
+++ b/.github/workflows/eval-check.yml
@@ -3,7 +3,8 @@ name: "Eval"
 on:
   push:
     branches: 'master'
-  pull_request_target:
+  pull_request:
+    branches: 'master'
 
 jobs:
   check:

--- a/.github/workflows/eval-checks.yml
+++ b/.github/workflows/eval-checks.yml
@@ -3,7 +3,8 @@ name: "Eval (Checks)"
 on:
   push:
     branches: 'master'
-  pull_request_target:
+  pull_request:
+    branches: 'master'
 
 jobs:
   wrangler:

--- a/.github/workflows/eval-devshells.yml
+++ b/.github/workflows/eval-devshells.yml
@@ -3,7 +3,8 @@ name: "Eval (devShells)"
 on:
   push:
     branches: 'master'
-  pull_request_target:
+  pull_request:
+    branches: 'master'
 
 jobs:
   wrangler:

--- a/.github/workflows/eval-format.yml
+++ b/.github/workflows/eval-format.yml
@@ -3,7 +3,8 @@ name: "Eval"
 on:
   push:
     branches: 'master'
-  pull_request_target:
+  pull_request:
+    branches: 'master'
 
 jobs:
   format:

--- a/.github/workflows/eval-packages.yml
+++ b/.github/workflows/eval-packages.yml
@@ -3,7 +3,8 @@ name: "Eval (Packages)"
 on:
   push:
     branches: 'master'
-  pull_request_target:
+  pull_request:
+    branches: 'master'
 
 jobs:
   wrangler:


### PR DESCRIPTION
Documentation for `pull_request_target`:
> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

The key part is `Avoid using this event if you need to build or run code from the pull request.` We definitely want to build the code in the pull request.

This PR will still fail the formatting check but it is required before the formatting can be fixed.